### PR TITLE
Add log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ You can use this action to activate a namespace in Okteto, download the correspo
 
 The namespace to activate. If empty, it will use your personal namespace.
 
+### `log-level`
+
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
+
 ## Outputs
 
 ### `kubeconfig`

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: 'The target Kubernetes namespace.'
     required: false
     default: ''
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
+    required: false 
 outputs:
   kubeconfig: 
     description: 'The path to the kubeconfig'
@@ -13,6 +16,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.namespace }}
+    - ${{ inputs.log-level }}
 branding:
   icon: 'arrow-up-circle'  
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"
   else
-    echo "log-level supported: debug, info, warn, error"
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
     exit 1
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,24 @@ if [ ! -z "$OKTETO_CA_CERT" ]; then
    update-ca-certificates
 fi
 
-echo running: okteto namespace "$namespace" $personal
-okteto namespace "$namespace" $personal
+log_level=$2
+if [ ! -z "$log_level" ]; then
+  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
+    log_level="--log-level ${log_level}"
+  else
+    echo "log-level supported: debug, info, warn, error"
+    exit 1
+  fi
+fi
+
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if [ "${RUNNER_DEBUG}" = "1" ]; then
+  log_level="--log-level debug"
+fi
+
+echo running: okteto namespace "$namespace" $personal $log_level
+okteto namespace "$namespace" $personal $log_level
 
 echo running: okteto kubeconfig
 eval okteto kubeconfig

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,4 +36,5 @@ echo running: okteto kubeconfig
 eval okteto kubeconfig
 
 k="/github/home/.kube/config"
+# TODO: update set-output https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
 echo "::set-output name=kubeconfig::$k"


### PR DESCRIPTION
Resolves https://okteto.atlassian.net/browse/DEV-320

As done for `deploy-preview` this PR adds the input of log-level to the action in order to enable debug logging or any other level the user wants to use on the runs.

Tested running the pipeline using the last commit 
https://github.com/teresaromero/go-getting-started/actions/workflows/test-actions.yml
