### PR TITLE
fix: support OKTETO_CA_CERT in minimal base images

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,12 @@ fi
 
 if [ ! -z "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
-   echo "$OKTETO_CA_CERT" > /usr/local/share/ca-certificates/okteto_ca_cert.crt
-   update-ca-certificates
+   echo "$OKTETO_CA_CERT" > /etc/ssl/certs/okteto_ca_cert.pem
+   if command -v update-ca-certificates > /dev/null 2>&1; then
+     mkdir -p /usr/local/share/ca-certificates
+     cp /etc/ssl/certs/okteto_ca_cert.pem /usr/local/share/ca-certificates/okteto_ca_cert.crt
+     update-ca-certificates
+   fi
 fi
 
 log_level=$2


### PR DESCRIPTION
## Summary

- `OKTETO_CA_CERT` was broken on all actions using `ghcr.io/okteto/okteto:master` as base image
- The base image does not have `/usr/local/share/ca-certificates/` directory or `update-ca-certificates` available
- Fix: write the cert directly to `/etc/ssl/certs/` which is where Go-based tools (okteto CLI, kubectl, helm) read certs from
- `update-ca-certificates` is called only if available, keeping compatibility with full Debian-based images (e.g. `deploy-preview`)

## Root cause

Two bugs in the original code:
1. `echo "$OKTETO_CA_CERT" > /usr/local/share/ca-certificates/okteto_ca_cert.crt` — directory does not exist in the base image
2. `update-ca-certificates` — command not found in the base image

## Test plan

- [x] Reproduced original error locally against a real Okteto instance
- [x] Verified fix by running the Docker image with `OKTETO_CA_CERT` set and confirming successful TLS connection